### PR TITLE
Feature/remove md divider after last group

### DIFF
--- a/src/main/resources/public/app/components/groupCard.component.html
+++ b/src/main/resources/public/app/components/groupCard.component.html
@@ -32,8 +32,7 @@
                     </div>        
                 </div> 
                 <md-button ng-disabled="$ctrl.groupStatus !== 'OPEN'" ng-click="$ctrl.gradeGroupMembers()" class="groupGradeBtn">GRADE</md-button>
-            </div><br>
-            <md-divider></md-divider>
+            </div>
         </md-card-content>
     </md-card>
 </div>


### PR DESCRIPTION
Bas heeft in zijn branch de divider op zijn pagina gehide, en bij Student Groups Overview is ie nu weggehaald omdat de cards vanzich zelf al goede spatiëring hebben. Closes #136 